### PR TITLE
maintenance: modernize BaikeSpider as a maintainable OSS project

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Copy these values into your shell environment before running BaikeSpider.
+# Example:
+#   export BAIKESPIDER_DB_USER=root
+#
+# Do not commit real passwords.
+
+BAIKESPIDER_DB_HOST=127.0.0.1
+BAIKESPIDER_DB_PORT=3306
+BAIKESPIDER_DB_USER=root
+BAIKESPIDER_DB_PASSWORD=
+BAIKESPIDER_DB_NAME=scrapy_baike

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Default code owner for the repository.
+* @yangqincheng
+
+# Project-facing documentation and contribution workflow.
+/README.md @yangqincheng
+/CONTRIBUTING.md @yangqincheng
+/.github/ @yangqincheng
+
+# Core crawler and persistence implementation.
+/scrapyspider/ @yangqincheng

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+name: Bug report
+description: Report a reproducible problem with BaikeSpider
+title: "[Bug]: "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a problem. Please include enough context to reproduce it.
+  - type: input
+    id: python
+    attributes:
+      label: Python version
+      placeholder: "e.g. 3.11.9"
+    validations:
+      required: true
+  - type: input
+    id: scrapy
+    attributes:
+      label: Scrapy version
+      placeholder: "e.g. 2.13.3"
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "e.g. macOS 15 / Ubuntu 24.04"
+    validations:
+      required: true
+  - type: textarea
+    id: command
+    attributes:
+      label: Command used
+      description: Include the exact command or entry point that triggered the problem.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or traceback
+      description: Remove credentials, cookies, tokens, or private data before posting.
+      render: shell
+  - type: input
+    id: baike_url
+    attributes:
+      label: Example Baidu Baike URL
+      description: Optional, but useful for selector/parser issues.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I removed credentials, tokens, cookies, and private data from this report.
+          required: true
+        - label: I searched existing issues for the same problem.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+name: Feature or improvement
+description: Suggest a focused improvement to BaikeSpider
+title: "[Enhancement]: "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Improvements that make the crawler easier to run, understand, test, or maintain are welcome.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What limitation or maintenance problem would this address?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: Describe the smallest useful change you have in mind.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Baidu Baike parsing/selectors
+        - Crawling and scheduling
+        - Deduplication
+        - MySQL persistence
+        - Image pipeline
+        - Configuration and security
+        - Tests and CI
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional. Mention workarounds or other approaches you considered.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: This request is focused on legitimate crawling, maintenance, research, or educational use.
+          required: true
+        - label: I searched existing issues for a similar proposal.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## What changed?
+
+<!-- Briefly describe the change. -->
+
+## Why?
+
+<!-- Explain the problem, maintenance need, or user-facing benefit. -->
+
+## Validation
+
+- [ ] I tested or otherwise validated the change.
+- [ ] I did not add credentials, tokens, cookies, private data, or generated crawl output.
+- [ ] I updated documentation when behavior or setup changed.
+- [ ] I kept the change focused and reviewable.
+
+### Environment (when relevant)
+
+- Python:
+- Scrapy:
+- OS:
+
+## Notes for the maintainer
+
+<!-- Add compatibility concerns, follow-up work, or screenshots/log excerpts if useful. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  syntax-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Compile Python sources
+        run: python -m compileall -q scrapyspider

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+.pytest_cache/
+.venv/
+venv/
+
+# Local configuration / credentials
+.env
+.env.local
+
+# Scrapy runtime state
+.scrapy/
+loginfo/
+
+# Generated images / crawl output
+scrapyspider/pictures/
+
+# Editors / OS
+.DS_Store
+.idea/
+.vscode/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing to BaikeSpider
+
+Thanks for your interest in improving BaikeSpider.
+
+BaikeSpider is maintained as an open-source reference implementation for Scrapy-based structured encyclopedia crawling. Contributions that improve compatibility, reliability, clarity, and reproducibility are especially useful.
+
+## Good contribution areas
+
+- update selectors for current Baidu Baike page structures;
+- improve compatibility with current Python and Scrapy versions;
+- move local configuration and credentials out of source code;
+- add dependency pinning or reproducible environment setup;
+- improve retry, timeout, and error handling;
+- add tests for parsing and persistence logic;
+- simplify legacy/demo code paths;
+- improve documentation and examples;
+- improve deduplication or large-crawl operational behavior.
+
+## Before opening a pull request
+
+1. Keep changes focused and easy to review.
+2. Explain the problem being solved and the approach taken.
+3. If changing crawler behavior, include the Python/Scrapy version you tested with.
+4. Do not commit real credentials, private data, or large generated crawl outputs.
+5. When updating selectors, describe the page structure or example entry used for validation.
+
+## Issues
+
+Bug reports are most useful when they include:
+
+- Python version;
+- Scrapy version;
+- operating system;
+- command used to run the spider;
+- relevant traceback or log excerpt;
+- example Baidu Baike page, when applicable.
+
+## Pull requests
+
+A good pull request should contain:
+
+- a concise title;
+- a short explanation of why the change is needed;
+- a summary of the implementation;
+- testing or validation notes.
+
+Small documentation-only fixes are welcome as well.
+
+## Responsible use
+
+Please keep contributions aligned with responsible crawling practices. Avoid changes whose primary purpose is to bypass access controls or enable unnecessarily aggressive request behavior.
+
+## Maintainer
+
+The repository is maintained by [@yangqincheng](https://github.com/yangqincheng).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,31 +2,51 @@
 
 Thanks for your interest in improving BaikeSpider.
 
-BaikeSpider is maintained as an open-source reference implementation for Scrapy-based structured encyclopedia crawling. Contributions that improve compatibility, reliability, clarity, and reproducibility are especially useful.
+BaikeSpider is maintained as an open-source reference implementation for Scrapy-based structured encyclopedia crawling. Contributions that improve compatibility, reliability, clarity, reproducibility, and responsible operation are especially useful.
 
 ## Good contribution areas
 
 - update selectors for current Baidu Baike page structures;
 - improve compatibility with current Python and Scrapy versions;
-- move local configuration and credentials out of source code;
-- add dependency pinning or reproducible environment setup;
+- improve local configuration and secret handling;
+- improve dependency pinning or reproducible environment setup;
 - improve retry, timeout, and error handling;
 - add tests for parsing and persistence logic;
+- migrate legacy SQL construction toward parameterized queries;
 - simplify legacy/demo code paths;
 - improve documentation and examples;
 - improve deduplication or large-crawl operational behavior.
+
+## Development setup
+
+1. Fork or clone the repository.
+2. Create a focused branch for your change.
+3. Install dependencies:
+
+   ```bash
+   python -m pip install -r requirements.txt
+   ```
+
+4. Configure local database settings using the `BAIKESPIDER_DB_*` environment variables documented in `.env.example`.
+5. Make the smallest coherent change that solves the problem.
+6. Run the repository checks before opening a pull request:
+
+   ```bash
+   python -m compileall -q scrapyspider
+   ```
 
 ## Before opening a pull request
 
 1. Keep changes focused and easy to review.
 2. Explain the problem being solved and the approach taken.
 3. If changing crawler behavior, include the Python/Scrapy version you tested with.
-4. Do not commit real credentials, private data, or large generated crawl outputs.
+4. Do not commit real credentials, private data, cookies, tokens, or large generated crawl outputs.
 5. When updating selectors, describe the page structure or example entry used for validation.
+6. Update the README when setup, configuration, or user-visible behavior changes.
 
 ## Issues
 
-Bug reports are most useful when they include:
+Use the provided GitHub issue templates when possible. Bug reports are most useful when they include:
 
 - Python version;
 - Scrapy version;
@@ -35,6 +55,8 @@ Bug reports are most useful when they include:
 - relevant traceback or log excerpt;
 - example Baidu Baike page, when applicable.
 
+Please redact credentials, cookies, tokens, and private data before posting logs.
+
 ## Pull requests
 
 A good pull request should contain:
@@ -42,13 +64,20 @@ A good pull request should contain:
 - a concise title;
 - a short explanation of why the change is needed;
 - a summary of the implementation;
-- testing or validation notes.
+- testing or validation notes;
+- compatibility notes when behavior depends on a particular Baidu Baike page structure.
 
 Small documentation-only fixes are welcome as well.
 
+Repository-wide ownership is declared in `.github/CODEOWNERS`; the primary maintainer reviews project changes.
+
 ## Responsible use
 
-Please keep contributions aligned with responsible crawling practices. Avoid changes whose primary purpose is to bypass access controls or enable unnecessarily aggressive request behavior.
+Please keep contributions aligned with responsible crawling practices. Avoid changes whose primary purpose is to bypass access controls, defeat anti-abuse mechanisms, or enable unnecessarily aggressive request behavior.
+
+## License
+
+By contributing to this repository, you agree that your contributions will be licensed under the repository's [MIT License](LICENSE).
 
 ## Maintainer
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018-2026 yangqincheng
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,34 @@
 # BaikeSpider
 
+[![CI](https://github.com/yangqincheng/baikespider/actions/workflows/ci.yml/badge.svg)](https://github.com/yangqincheng/baikespider/actions/workflows/ci.yml)
 [![GitHub stars](https://img.shields.io/github/stars/yangqincheng/baikespider?style=flat-square)](https://github.com/yangqincheng/baikespider/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/yangqincheng/baikespider?style=flat-square)](https://github.com/yangqincheng/baikespider/network/members)
+[![License](https://img.shields.io/github/license/yangqincheng/baikespider?style=flat-square)](LICENSE)
 [![Python](https://img.shields.io/badge/language-Python-blue?style=flat-square)](https://www.python.org/)
+[![Scrapy](https://img.shields.io/badge/framework-Scrapy-60A839?style=flat-square)](https://scrapy.org/)
 
 **BaikeSpider** is an open-source Scrapy project for collecting structured data from Baidu Baike. It starts from multiple seed entries, follows related-entry links, extracts structured metadata, records polysemy/synonym information, persists data to MySQL, and can download representative images for collected entities.
 
-The repository is useful as a reference implementation for recursive web crawling, structured encyclopedia extraction, entity deduplication, Scrapy pipelines, MySQL persistence, and knowledge-base / knowledge-graph data preparation.
+The project is intended as a practical reference for **recursive web crawling, structured encyclopedia extraction, entity deduplication, Scrapy pipelines, MySQL persistence, and knowledge-base / knowledge-graph data preparation**.
 
 > **Project status**
 >
 > BaikeSpider is maintained as an open-source reference implementation. The crawler was originally built against an earlier Baidu Baike page structure, so upstream DOM or anti-crawling changes may require selector or dependency updates before production use. Compatibility fixes, documentation improvements, tests, and modernization contributions are welcome.
+
+## At a glance
+
+| Area | Current implementation |
+| --- | --- |
+| Language | Python |
+| Crawling framework | Scrapy |
+| Primary spider | `baike` |
+| Image spider | `pic` |
+| Persistence | MySQL via PyMySQL |
+| Deduplication | Scrapy request filtering + database-level entity checks |
+| Long-running crawl support | Scrapy `JOBDIR` |
+| Optional distributed-crawl components | `scrapy-redis` |
+| Maintainer | [@yangqincheng](https://github.com/yangqincheng) |
+| License | MIT |
 
 ## Highlights
 
@@ -22,6 +40,7 @@ The repository is useful as a reference implementation for recursive web crawlin
 - **Image crawling pipeline** — downloads representative entry images and associates them with collected entities.
 - **Resumable crawling** — supports Scrapy `JOBDIR` for interruptible long-running tasks.
 - **Bloom filter experiment** — includes a Bloom filter implementation for deduplication-related experiments.
+- **Open-source maintenance workflow** — includes CI, contribution guidance, issue/PR templates, and explicit code ownership.
 
 ## How it works
 
@@ -79,8 +98,14 @@ The image pipeline can additionally associate downloaded image names with entity
 ```text
 baikespider/
 ├── .env.example
+├── .github/
+│   ├── CODEOWNERS
+│   ├── ISSUE_TEMPLATE/
+│   ├── PULL_REQUEST_TEMPLATE.md
+│   └── workflows/
 ├── .gitignore
 ├── CONTRIBUTING.md
+├── LICENSE
 ├── README.md
 ├── requirements.txt
 ├── scrapy.cfg
@@ -120,11 +145,11 @@ cd baikespider
 python -m pip install -r requirements.txt
 ```
 
-The declared dependencies are Scrapy, PyMySQL, and `scrapy-redis`. Because this codebase originated several years ago, newer Python/Scrapy versions may still require small compatibility changes. If you encounter one, please open an issue with your environment details.
+The declared dependencies are Scrapy, PyMySQL, and `scrapy-redis`. Because this codebase originated several years ago, newer Python/Scrapy versions may still require compatibility changes. If you encounter one, please open an issue with your environment details.
 
 ### 3. Configure MySQL
 
-BaikeSpider no longer keeps database credentials in source code. Configure the connection with environment variables:
+BaikeSpider does not keep database credentials in source code. Configure the connection with environment variables:
 
 ```bash
 export BAIKESPIDER_DB_HOST=127.0.0.1
@@ -134,7 +159,7 @@ export BAIKESPIDER_DB_PASSWORD='your-password'
 export BAIKESPIDER_DB_NAME=scrapy_baike
 ```
 
-See `.env.example` for the full set of variables. The code uses safe local defaults for host, port, username, and database name, while the password defaults to an empty value.
+See `.env.example` for the full set of variables. The code uses local-development defaults for host, port, username, and database name, while the password defaults to an empty value.
 
 > Do not commit real credentials or production configuration.
 
@@ -201,9 +226,21 @@ The MySQL pipeline executes generated SQL statements, commits successful operati
 
 Scrapy's `JOBDIR` mechanism persists scheduler state, allowing the crawler to resume after an intentional stop instead of restarting from the seed set.
 
-## Maintenance priorities
+## Maintenance and open-source workflow
 
-Current modernization priorities include:
+BaikeSpider has been public since 2018. The current maintenance effort is focused on making the repository easier to understand, run, review, and contribute to while preserving the original project and its history.
+
+Repository maintenance now includes:
+
+- a documented dependency set;
+- environment-based local database configuration;
+- GitHub Actions syntax/dependency checks;
+- `CODEOWNERS` identifying the primary maintainer;
+- structured bug and improvement issue templates;
+- a pull request template and contribution guide;
+- an explicit MIT open-source license.
+
+### Current priorities
 
 - update selectors for the current Baidu Baike DOM;
 - verify and document supported Python/Scrapy versions;
@@ -213,26 +250,28 @@ Current modernization priorities include:
 - simplify legacy/demo code paths;
 - document larger-scale crawl operational practices.
 
-Contributions in these areas are especially welcome.
-
 ## Contributing
 
 Issues and pull requests are welcome. Good contributions include compatibility fixes, parser improvements, documentation corrections, safer configuration, tests, and crawler reliability improvements.
 
-Please see [CONTRIBUTING.md](CONTRIBUTING.md) for the contribution guide.
+See [CONTRIBUTING.md](CONTRIBUTING.md) before submitting a larger change. GitHub issue and pull request templates are provided to keep reports reproducible and changes easy to review.
 
 ## Maintainer
 
-BaikeSpider is owned and maintained by [@yangqincheng](https://github.com/yangqincheng).
+BaikeSpider is owned and maintained by [@yangqincheng](https://github.com/yangqincheng). Repository-wide ownership is also declared in [`.github/CODEOWNERS`](.github/CODEOWNERS).
 
-The repository has been public since 2018 and has attracted community stars and forks over time. The current maintenance effort focuses on preserving the project as a useful, understandable reference for Scrapy-based structured encyclopedia crawling while progressively improving compatibility, configuration safety, and maintainability.
+The repository has attracted community stars and forks over time. The maintenance goal is to keep it useful as an understandable open-source reference for Scrapy-based structured encyclopedia crawling while progressively improving compatibility, configuration safety, testing, and maintainability.
 
 ## Responsible use
 
 This repository is intended for learning, research, and engineering reference purposes. If you run the crawler against a third-party website, respect the website's terms, robots policies where applicable, rate limits, applicable laws, and the rights of data owners. Avoid unnecessarily aggressive request rates.
 
+## License
+
+BaikeSpider is released under the [MIT License](LICENSE).
+
 ## 中文说明
 
 BaikeSpider 是一个基于 Scrapy 的百度百科结构化数据爬虫。项目从多个初始百科词条出发，递归发现相关词条，并提取词条名称、简介、Infobox、标签、相关链接以及多义词信息，最终保存到 MySQL；同时包含词条图片抓取、数据库二次去重和 `JOBDIR` 断点续爬等实现。
 
-当前仓库主要作为 **Scrapy 爬虫、百科实体采集和结构化数据预处理的开源参考实现** 进行维护。近期维护重点包括文档整理、数据库配置安全化、依赖声明以及修复持久化流程中的明显问题。由于百度百科页面结构可能发生变化，实际运行前仍可能需要更新 XPath / selector 或依赖版本。
+当前仓库主要作为 **Scrapy 爬虫、百科实体采集和结构化数据预处理的开源参考实现** 进行维护。近期维护已补充 MIT License、CI、CODEOWNERS、贡献指南、Issue/PR 模板、依赖声明和更安全的数据库配置，并修复了持久化流程中的明显问题。由于百度百科页面结构可能发生变化，实际运行前仍可能需要更新 XPath / selector 或依赖版本。

--- a/README.md
+++ b/README.md
@@ -4,28 +4,26 @@
 [![GitHub forks](https://img.shields.io/github/forks/yangqincheng/baikespider?style=flat-square)](https://github.com/yangqincheng/baikespider/network/members)
 [![Python](https://img.shields.io/badge/language-Python-blue?style=flat-square)](https://www.python.org/)
 
-**BaikeSpider** is an open-source Scrapy project for collecting structured data from Baidu Baike. It crawls encyclopedia entities from multiple seed pages, follows related-entry links, extracts structured metadata, records polysemy/synonym information, and can download representative images for collected entities.
+**BaikeSpider** is an open-source Scrapy project for collecting structured data from Baidu Baike. It starts from multiple seed entries, follows related-entry links, extracts structured metadata, records polysemy/synonym information, persists data to MySQL, and can download representative images for collected entities.
 
-The project was created as a practical implementation of large-scale encyclopedia crawling and structured-data preprocessing. It is useful as a reference for Scrapy crawling pipelines, recursive graph-style traversal, entity deduplication, MySQL persistence, and knowledge-base / knowledge-graph data preparation experiments.
+The repository is useful as a reference implementation for recursive web crawling, structured encyclopedia extraction, entity deduplication, Scrapy pipelines, MySQL persistence, and knowledge-base / knowledge-graph data preparation.
 
 > **Project status**
 >
-> BaikeSpider is maintained as an open-source reference implementation. The current crawler was originally built against an earlier Baidu Baike page structure, so upstream DOM or anti-crawling changes may require selector or dependency updates before production use. Compatibility fixes, documentation improvements, and modernization contributions are welcome.
+> BaikeSpider is maintained as an open-source reference implementation. The crawler was originally built against an earlier Baidu Baike page structure, so upstream DOM or anti-crawling changes may require selector or dependency updates before production use. Compatibility fixes, documentation improvements, tests, and modernization contributions are welcome.
 
 ## Highlights
 
-- **Recursive entity discovery** — starts from multiple seed entries and follows related Baidu Baike links to discover additional entities.
-- **Structured extraction** — captures entity name, summary/description, infobox fields, tags, related infobox links, and entry identifiers.
-- **Polysemy / synonym modeling** — stores multiple meanings and corresponding entry identifiers in a separate table.
-- **Two-layer deduplication** — uses Scrapy request deduplication during crawling and performs an additional database-level check before insertion.
-- **MySQL persistence** — stores crawled entities and synonym/polysemy relationships in structured tables.
+- **Recursive entity discovery** — starts from multiple seed entries and follows related Baidu Baike links.
+- **Structured extraction** — captures names, summaries, infobox fields, tags, related links, and entry identifiers.
+- **Polysemy / synonym modeling** — stores multiple meanings and corresponding entry identifiers separately.
+- **Two-layer deduplication** — combines Scrapy request filtering with database-level checks before insertion.
+- **MySQL persistence** — stores entities and synonym/polysemy relationships in structured tables.
 - **Image crawling pipeline** — downloads representative entry images and associates them with collected entities.
-- **Resumable crawling** — supports Scrapy `JOBDIR`, allowing long-running crawling tasks to be stopped and resumed.
+- **Resumable crawling** — supports Scrapy `JOBDIR` for interruptible long-running tasks.
 - **Bloom filter experiment** — includes a Bloom filter implementation for deduplication-related experiments.
 
 ## How it works
-
-BaikeSpider treats Baidu Baike as a graph of connected encyclopedia entries.
 
 ```text
 Seed entries
@@ -49,15 +47,11 @@ Fetch Baidu Baike page
         Schedule next entries
 ```
 
-This traversal continues as Scrapy discovers new entry URLs. Scrapy filters duplicate requests, while the persistence layer performs an additional check by entity identifier before inserting records.
+Scrapy filters duplicate requests during traversal, while the persistence layer checks entity identifiers before inserting records into MySQL.
 
 ## Data model
 
-The crawler primarily works with two tables.
-
 ### `entity_table`
-
-Stores the structured representation of a Baidu Baike entry.
 
 | Field | Description |
 | --- | --- |
@@ -70,8 +64,6 @@ Stores the structured representation of a Baidu Baike entry.
 | `tag` | Baidu Baike entry tags |
 
 ### `synonym_table`
-
-Stores polysemy / same-name relationships.
 
 | Field | Description |
 | --- | --- |
@@ -86,7 +78,11 @@ The image pipeline can additionally associate downloaded image names with entity
 
 ```text
 baikespider/
+├── .env.example
+├── .gitignore
+├── CONTRIBUTING.md
 ├── README.md
+├── requirements.txt
 ├── scrapy.cfg
 └── scrapyspider/
     ├── Bloomfilter.py
@@ -95,7 +91,6 @@ baikespider/
     ├── pipelines.py
     ├── request_seen.py
     ├── settings.py
-    ├── picture/
     └── spiders/
         ├── BaiDuSpider.py
         ├── Picture_Spider.py
@@ -103,7 +98,7 @@ baikespider/
         └── test_spider.py
 ```
 
-The main Baidu Baike implementation lives in `scrapyspider/spiders/BaiDuSpider.py`:
+The primary Baidu Baike implementation lives in `scrapyspider/spiders/BaiDuSpider.py`:
 
 - `BaiKeSpider` (`name = "baike"`) crawls and stores structured encyclopedia entries.
 - `PicturesSpider` (`name = "pic"`) reads collected entity identifiers and downloads representative images.
@@ -121,29 +116,35 @@ cd baikespider
 
 ### 2. Install dependencies
 
-The project uses Scrapy and PyMySQL. `urllib` functionality used by the crawler is provided by Python's standard library.
-
 ```bash
-pip install scrapy pymysql
+python -m pip install -r requirements.txt
 ```
 
-Because this codebase originated several years ago, newer Scrapy/Python versions may require small compatibility changes. If you run into one, please open an issue or submit a pull request with the environment details.
+The declared dependencies are Scrapy, PyMySQL, and `scrapy-redis`. Because this codebase originated several years ago, newer Python/Scrapy versions may still require small compatibility changes. If you encounter one, please open an issue with your environment details.
 
 ### 3. Configure MySQL
 
-Create a MySQL database (the original project uses `scrapy_baike`) and configure the connection parameters in `scrapyspider/pipelines.py` before running the crawler.
+BaikeSpider no longer keeps database credentials in source code. Configure the connection with environment variables:
 
-The pipeline contains helper methods for creating the entity and synonym tables. The expected schemas are documented in the [Data model](#data-model) section above.
+```bash
+export BAIKESPIDER_DB_HOST=127.0.0.1
+export BAIKESPIDER_DB_PORT=3306
+export BAIKESPIDER_DB_USER=root
+export BAIKESPIDER_DB_PASSWORD='your-password'
+export BAIKESPIDER_DB_NAME=scrapy_baike
+```
 
-> **Security note:** do not commit production database credentials. Replace local-development defaults with credentials appropriate for your own environment.
+See `.env.example` for the full set of variables. The code uses safe local defaults for host, port, username, and database name, while the password defaults to an empty value.
+
+> Do not commit real credentials or production configuration.
 
 ### 4. Configure image storage
 
-If you want to run the image crawler, configure `IMAGES_STORE` in `scrapyspider/settings.py` to point to the directory where downloaded images should be stored.
+If you want to run the image crawler, configure `IMAGES_STORE` in `scrapyspider/settings.py`. The current default is a repository-local pictures directory, which is ignored by Git.
 
 ### 5. Run the entity crawler
 
-Run commands from the directory containing `scrapy.cfg`.
+Run commands from the directory containing `scrapy.cfg`:
 
 ```bash
 scrapy crawl baike -s JOBDIR=loginfo/baike
@@ -151,7 +152,7 @@ scrapy crawl baike -s JOBDIR=loginfo/baike
 
 `JOBDIR` stores crawler state so an interrupted crawl can later resume. Use a separate job directory for each spider.
 
-To stop a running crawl gracefully, press `Ctrl+C` and allow Scrapy to finish persisting its state. Restarting with the same `JOBDIR` resumes the crawl.
+To stop a running crawl gracefully, press `Ctrl+C` and allow Scrapy to persist its state. Restarting with the same `JOBDIR` resumes the crawl.
 
 ### 6. Run the image crawler
 
@@ -165,16 +166,16 @@ The image crawler reads entity identifiers from `entity_table`, visits the corre
 
 ## Core extraction fields
 
-`BaiKeItem` currently exposes the following fields:
+`BaiKeItem` currently exposes:
 
 ```text
 name
- descrip
- infobox
- tag
- oid
- infolink
- polysemy
+descrip
+infobox
+tag
+oid
+infolink
+polysemy
 ```
 
 `PicturesItem` tracks image URLs, downloaded image metadata, file paths, image names, counters, and the corresponding entity identifier.
@@ -183,30 +184,32 @@ name
 
 ### Recursive crawling
 
-The entity crawler begins with a diverse set of seed entries and then discovers additional `/item/...` links from each fetched page. This turns the crawler into a breadth of connected encyclopedia entries rather than a fixed list scraper.
+The entity crawler starts from a diverse set of seed entries and discovers additional `/item/...` links from each fetched page, turning the crawl into a traversal of connected encyclopedia entries rather than a fixed-list scraper.
 
 ### Deduplication
 
 Two levels of deduplication are used:
 
-1. Scrapy's request filtering prevents the same URL from being scheduled repeatedly.
-2. Before writing to MySQL, the pipeline checks whether the corresponding `oid` is already present.
+1. Scrapy's request filtering prevents repeated scheduling of the same URL.
+2. Before writing to MySQL, the pipeline checks whether the corresponding entity identifier is already present.
 
-This is particularly useful when multiple pages lead to the same entity or when polysemous entry names are involved.
+### Persistence
+
+The MySQL pipeline executes generated SQL statements, commits successful operations, and closes the database connection after each operation. Database connection settings are read from `BAIKESPIDER_DB_*` environment variables so local credentials do not need to live in the repository.
 
 ### Resumability
 
-Long-running crawls are expected to be interruptible. Scrapy's `JOBDIR` mechanism persists scheduler state, allowing the crawler to resume from the previous run instead of restarting from the seed set.
+Scrapy's `JOBDIR` mechanism persists scheduler state, allowing the crawler to resume after an intentional stop instead of restarting from the seed set.
 
 ## Maintenance priorities
 
-The repository is intentionally kept public as a working/reference implementation. Useful future improvements include:
+Current modernization priorities include:
 
 - update selectors for the current Baidu Baike DOM;
-- move database configuration fully to environment variables or a local config file;
-- add pinned dependency versions and reproducible environment setup;
-- improve error handling and retry behavior;
-- add automated tests for parsers and persistence logic;
+- verify and document supported Python/Scrapy versions;
+- add parser and persistence tests;
+- migrate legacy SQL construction toward parameterized queries;
+- improve retry, timeout, and error handling;
 - simplify legacy/demo code paths;
 - document larger-scale crawl operational practices.
 
@@ -216,13 +219,13 @@ Contributions in these areas are especially welcome.
 
 Issues and pull requests are welcome. Good contributions include compatibility fixes, parser improvements, documentation corrections, safer configuration, tests, and crawler reliability improvements.
 
-Please see [CONTRIBUTING.md](CONTRIBUTING.md) for a lightweight contribution guide.
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for the contribution guide.
 
 ## Maintainer
 
 BaikeSpider is owned and maintained by [@yangqincheng](https://github.com/yangqincheng).
 
-The repository has been public since 2018 and has attracted community stars and forks over time. The goal of the current maintenance effort is to preserve the project as a useful, understandable reference for Scrapy-based structured encyclopedia crawling while progressively improving compatibility and maintainability.
+The repository has been public since 2018 and has attracted community stars and forks over time. The current maintenance effort focuses on preserving the project as a useful, understandable reference for Scrapy-based structured encyclopedia crawling while progressively improving compatibility, configuration safety, and maintainability.
 
 ## Responsible use
 
@@ -232,4 +235,4 @@ This repository is intended for learning, research, and engineering reference pu
 
 BaikeSpider 是一个基于 Scrapy 的百度百科结构化数据爬虫。项目从多个初始百科词条出发，递归发现相关词条，并提取词条名称、简介、Infobox、标签、相关链接以及多义词信息，最终保存到 MySQL；同时包含词条图片抓取、数据库二次去重和 `JOBDIR` 断点续爬等实现。
 
-这个仓库目前主要作为 **Scrapy 爬虫、百科实体采集和结构化数据预处理的开源参考实现** 进行维护。由于百度百科页面结构可能发生变化，实际运行前可能需要更新 XPath / selector 或依赖版本。如果你发现兼容性问题，欢迎提交 Issue 或 Pull Request。
+当前仓库主要作为 **Scrapy 爬虫、百科实体采集和结构化数据预处理的开源参考实现** 进行维护。近期维护重点包括文档整理、数据库配置安全化、依赖声明以及修复持久化流程中的明显问题。由于百度百科页面结构可能发生变化，实际运行前仍可能需要更新 XPath / selector 或依赖版本。

--- a/README.md
+++ b/README.md
@@ -1,70 +1,235 @@
-# baikespider
-BaiKe Spider
+# BaikeSpider
 
-scrapy框架写的爬取百度百科的代码
+[![GitHub stars](https://img.shields.io/github/stars/yangqincheng/baikespider?style=flat-square)](https://github.com/yangqincheng/baikespider/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/yangqincheng/baikespider?style=flat-square)](https://github.com/yangqincheng/baikespider/network/members)
+[![Python](https://img.shields.io/badge/language-Python-blue?style=flat-square)](https://www.python.org/)
 
-数据库中一共有两张表 一张是实体表entity_table,一张是同名词表synonym_table，数据实体截图放在/picture文件夹下
+**BaikeSpider** is an open-source Scrapy project for collecting structured data from Baidu Baike. It crawls encyclopedia entities from multiple seed pages, follows related-entry links, extracts structured metadata, records polysemy/synonym information, and can download representative images for collected entities.
 
-保存的图片截图也放在/picture下
+The project was created as a practical implementation of large-scale encyclopedia crawling and structured-data preprocessing. It is useful as a reference for Scrapy crawling pipelines, recursive graph-style traversal, entity deduplication, MySQL persistence, and knowledge-base / knowledge-graph data preparation experiments.
 
-spider文件夹中的BaiDuSpider是最终的确定的结果，其余的DouBanSpider是开始学习时候看的demo，PictureSpider是开始爬取图片时用来测试的。
+> **Project status**
+>
+> BaikeSpider is maintained as an open-source reference implementation. The current crawler was originally built against an earlier Baidu Baike page structure, so upstream DOM or anti-crawling changes may require selector or dependency updates before production use. Compatibility fixes, documentation improvements, and modernization contributions are welcome.
 
-BaiDuSpider中有两个Spider 一个是用来获取百科词条的内容（词条名字，简介，相关领域等，可以参看数据库表的截图）和同义词之间的内容
+## Highlights
 
-代码内部有详细的注释
+- **Recursive entity discovery** — starts from multiple seed entries and follows related Baidu Baike links to discover additional entities.
+- **Structured extraction** — captures entity name, summary/description, infobox fields, tags, related infobox links, and entry identifiers.
+- **Polysemy / synonym modeling** — stores multiple meanings and corresponding entry identifiers in a separate table.
+- **Two-layer deduplication** — uses Scrapy request deduplication during crawling and performs an additional database-level check before insertion.
+- **MySQL persistence** — stores crawled entities and synonym/polysemy relationships in structured tables.
+- **Image crawling pipeline** — downloads representative entry images and associates them with collected entities.
+- **Resumable crawling** — supports Scrapy `JOBDIR`, allowing long-running crawling tasks to be stopped and resumed.
+- **Bloom filter experiment** — includes a Bloom filter implementation for deduplication-related experiments.
 
-主要思想是我们从多个初始节点出发，保存当前页面我们需要保存的信息，然后把页面中的其他词条的链接作为下一跳。Scrapy框架本身有查重机制，我们在保存到数据库时也会再次查重（因为有同名词表）这是entity_table表收集的信息的主要思想
+## How it works
 
-synonym_table表收集的信息的主要思想是从entity_table表中读取每个词条的url，然后保存当前的词条中的第一张词条图片，并改名为OID+编号的形式，OID是实体表entity_table中每项数据的唯一标识,来源于每个词条url后面的item/数字/
+BaikeSpider treats Baidu Baike as a graph of connected encyclopedia entries.
 
-具体的操作文档也放在/picture文件夹下
+```text
+Seed entries
+    |
+    v
+Fetch Baidu Baike page
+    |
+    +--> Extract entity metadata
+    |      - name
+    |      - description
+    |      - infobox
+    |      - tags
+    |      - related links
+    |      - polysemy data
+    |
+    +--> Persist structured data to MySQL
+    |
+    +--> Discover /item/... links
+             |
+             v
+        Schedule next entries
+```
 
-操作部分：
-1.实际项目中的代码目录是这样
+This traversal continues as Scrapy discovers new entry URLs. Scrapy filters duplicate requests, while the persistence layer performs an additional check by entity identifier before inserting records.
 
-![image](https://user-images.githubusercontent.com/23690625/109646793-7f3c4f80-7b93-11eb-9c22-d0ccfceeda70.png)
+## Data model
 
-几个文件夹的含义
-（1）	loginfo 这是由我们自己定义的用来保存爬虫当前运行状态的文件夹，位置由我们自己决定，这里我们用的相对路径，所以项目保存在运行起点的文件夹里。
-（2）	pictures 是我们用来保存爬取的图片的文件夹，位置可以由我们自己修改，如果想要改变图片的存储路径，修改settings.py文件里的IMAGES_STORE。
-如下图
-![image](https://user-images.githubusercontent.com/23690625/109646839-8c593e80-7b93-11eb-8785-ce2fdff7ba17.png)
+The crawler primarily works with two tables.
 
- (3)  spiders文件夹存储我们写的spider文件
- 2.启动爬虫需要在命令行中启动，启动的路径取决于scrapy.cfg 文件所在的位置
+### `entity_table`
 
-比如在我电脑中scrapy.cfg 文件位于 ![image](https://user-images.githubusercontent.com/23690625/109646881-9d09b480-7b93-11eb-887c-088d56fd8069.png)
-,那么我启动的位置就该在这个地方
+Stores the structured representation of a Baidu Baike entry.
 
-启动的命令
-Name 是一个爬虫的唯一标识，百科的爬虫的name就是 baike， 图片爬虫的name就是pic,JOBDIR 后面就是我们存储爬虫当前运行状态的路径（注意这里每个爬虫当前信息的保存路径不能是一样的）所以如果要在自己的地方运行，那么启动命令就应该这么写
+| Field | Description |
+| --- | --- |
+| `id` | Auto-increment database identifier |
+| `oid` | Entry identifier derived from the Baidu Baike URL |
+| `name` | Entity / entry name |
+| `descrip` | Entry summary |
+| `infobox` | Structured infobox fields serialized as text |
+| `infolink` | Links discovered from infobox values |
+| `tag` | Baidu Baike entry tags |
 
-上面是启动命令，如果我们需要暂时结束今天的爬虫任务，那么我们只需要在命令行中使用按下 ctrl+c 就行（注意按下之后需要等大概10秒,出现类似下图的图片就可以终止了）
+### `synonym_table`
 
-![image](https://user-images.githubusercontent.com/23690625/109646920-a8f57680-7b93-11eb-83d4-3e684172fb90.png)
+Stores polysemy / same-name relationships.
 
-如果我们需要重新启动爬虫，只需要输入启动命令我们就可以重新启动爬虫了。
-3.	需要在本地修改的地方
+| Field | Description |
+| --- | --- |
+| `id` | Auto-increment database identifier |
+| `name` | Shared entity name |
+| `descrip` | Meaning / description for the corresponding sense |
+| `oid` | Entry identifier for that sense |
 
-（1）	当前运行状态的保存 
-在启动命令的JOBDIR后修改即可，这里使用相对路径即可，请不要使用绝对路径
-（2）	图片的存储目录
-前面已经说了，请查看第一点
-（3）	数据库的连接
-数据库的地址，端口，用户名，密码等请在pipeline.py 文件中BaiKeSpiderPipeline类里面的_init_函数修改，如下图,一般只需要修改user和password
+The image pipeline can additionally associate downloaded image names with entity records.
 
-![image](https://user-images.githubusercontent.com/23690625/109646951-b3b00b80-7b93-11eb-872b-bcbba4eb4c6b.png)
+## Repository structure
 
-4.	附录 SQL语句
+```text
+baikespider/
+├── README.md
+├── scrapy.cfg
+└── scrapyspider/
+    ├── Bloomfilter.py
+    ├── items.py
+    ├── middlewares.py
+    ├── pipelines.py
+    ├── request_seen.py
+    ├── settings.py
+    ├── picture/
+    └── spiders/
+        ├── BaiDuSpider.py
+        ├── Picture_Spider.py
+        ├── douban_spider.py
+        └── test_spider.py
+```
 
-![image](https://user-images.githubusercontent.com/23690625/109646978-be6aa080-7b93-11eb-8c86-ca8a1d42ab04.png)
-![image](https://user-images.githubusercontent.com/23690625/109646997-c4608180-7b93-11eb-8ce9-b55a80761f8f.png)
+The main Baidu Baike implementation lives in `scrapyspider/spiders/BaiDuSpider.py`:
 
-需要安装的packages
-Scrapy,urllib,pymysql 
+- `BaiKeSpider` (`name = "baike"`) crawls and stores structured encyclopedia entries.
+- `PicturesSpider` (`name = "pic"`) reads collected entity identifiers and downloads representative images.
 
-5.	可能会遇到的情况
-有时会出现pic爬虫突然正常中止，这是因为baike爬虫收集的数据里的OID都已经被读取，这个时候只需要等待一会，用同样的启动命令启动pic爬虫即可。（这种情况很少出现）
+`douban_spider.py` and some test code are retained from the project's early Scrapy learning / experimentation stage and are not the primary Baike crawler.
 
+## Getting started
 
+### 1. Clone the repository
 
+```bash
+git clone https://github.com/yangqincheng/baikespider.git
+cd baikespider
+```
+
+### 2. Install dependencies
+
+The project uses Scrapy and PyMySQL. `urllib` functionality used by the crawler is provided by Python's standard library.
+
+```bash
+pip install scrapy pymysql
+```
+
+Because this codebase originated several years ago, newer Scrapy/Python versions may require small compatibility changes. If you run into one, please open an issue or submit a pull request with the environment details.
+
+### 3. Configure MySQL
+
+Create a MySQL database (the original project uses `scrapy_baike`) and configure the connection parameters in `scrapyspider/pipelines.py` before running the crawler.
+
+The pipeline contains helper methods for creating the entity and synonym tables. The expected schemas are documented in the [Data model](#data-model) section above.
+
+> **Security note:** do not commit production database credentials. Replace local-development defaults with credentials appropriate for your own environment.
+
+### 4. Configure image storage
+
+If you want to run the image crawler, configure `IMAGES_STORE` in `scrapyspider/settings.py` to point to the directory where downloaded images should be stored.
+
+### 5. Run the entity crawler
+
+Run commands from the directory containing `scrapy.cfg`.
+
+```bash
+scrapy crawl baike -s JOBDIR=loginfo/baike
+```
+
+`JOBDIR` stores crawler state so an interrupted crawl can later resume. Use a separate job directory for each spider.
+
+To stop a running crawl gracefully, press `Ctrl+C` and allow Scrapy to finish persisting its state. Restarting with the same `JOBDIR` resumes the crawl.
+
+### 6. Run the image crawler
+
+After entity data has been collected into MySQL:
+
+```bash
+scrapy crawl pic -s JOBDIR=loginfo/pic
+```
+
+The image crawler reads entity identifiers from `entity_table`, visits the corresponding Baidu Baike pages, downloads representative images, and stores the image mapping through the pipeline.
+
+## Core extraction fields
+
+`BaiKeItem` currently exposes the following fields:
+
+```text
+name
+ descrip
+ infobox
+ tag
+ oid
+ infolink
+ polysemy
+```
+
+`PicturesItem` tracks image URLs, downloaded image metadata, file paths, image names, counters, and the corresponding entity identifier.
+
+## Design notes
+
+### Recursive crawling
+
+The entity crawler begins with a diverse set of seed entries and then discovers additional `/item/...` links from each fetched page. This turns the crawler into a breadth of connected encyclopedia entries rather than a fixed list scraper.
+
+### Deduplication
+
+Two levels of deduplication are used:
+
+1. Scrapy's request filtering prevents the same URL from being scheduled repeatedly.
+2. Before writing to MySQL, the pipeline checks whether the corresponding `oid` is already present.
+
+This is particularly useful when multiple pages lead to the same entity or when polysemous entry names are involved.
+
+### Resumability
+
+Long-running crawls are expected to be interruptible. Scrapy's `JOBDIR` mechanism persists scheduler state, allowing the crawler to resume from the previous run instead of restarting from the seed set.
+
+## Maintenance priorities
+
+The repository is intentionally kept public as a working/reference implementation. Useful future improvements include:
+
+- update selectors for the current Baidu Baike DOM;
+- move database configuration fully to environment variables or a local config file;
+- add pinned dependency versions and reproducible environment setup;
+- improve error handling and retry behavior;
+- add automated tests for parsers and persistence logic;
+- simplify legacy/demo code paths;
+- document larger-scale crawl operational practices.
+
+Contributions in these areas are especially welcome.
+
+## Contributing
+
+Issues and pull requests are welcome. Good contributions include compatibility fixes, parser improvements, documentation corrections, safer configuration, tests, and crawler reliability improvements.
+
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for a lightweight contribution guide.
+
+## Maintainer
+
+BaikeSpider is owned and maintained by [@yangqincheng](https://github.com/yangqincheng).
+
+The repository has been public since 2018 and has attracted community stars and forks over time. The goal of the current maintenance effort is to preserve the project as a useful, understandable reference for Scrapy-based structured encyclopedia crawling while progressively improving compatibility and maintainability.
+
+## Responsible use
+
+This repository is intended for learning, research, and engineering reference purposes. If you run the crawler against a third-party website, respect the website's terms, robots policies where applicable, rate limits, applicable laws, and the rights of data owners. Avoid unnecessarily aggressive request rates.
+
+## 中文说明
+
+BaikeSpider 是一个基于 Scrapy 的百度百科结构化数据爬虫。项目从多个初始百科词条出发，递归发现相关词条，并提取词条名称、简介、Infobox、标签、相关链接以及多义词信息，最终保存到 MySQL；同时包含词条图片抓取、数据库二次去重和 `JOBDIR` 断点续爬等实现。
+
+这个仓库目前主要作为 **Scrapy 爬虫、百科实体采集和结构化数据预处理的开源参考实现** 进行维护。由于百度百科页面结构可能发生变化，实际运行前可能需要更新 XPath / selector 或依赖版本。如果你发现兼容性问题，欢迎提交 Issue 或 Pull Request。

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Scrapy
+PyMySQL
+scrapy-redis

--- a/scrapyspider/pipelines.py
+++ b/scrapyspider/pipelines.py
@@ -4,16 +4,15 @@
 #
 # Don't forget to add your pipeline to the ITEM_PIPELINES setting
 # See: https://doc.scrapy.org/en/latest/topics/item-pipeline.html
-import pymysql.cursors
-import sys
-from scrapy import Request
-
-from scrapy.pipelines.images import ImagesPipeline
-from scrapy.exceptions import DropItem
-from scrapy.utils.project import get_project_settings
-
-import re
 import os
+import re
+import sys
+
+import pymysql.cursors
+from scrapy import Request
+from scrapy.exceptions import DropItem
+from scrapy.pipelines.images import ImagesPipeline
+from scrapy.utils.project import get_project_settings
 
 
 class BaiKeSpiderPipeline(object):
@@ -22,14 +21,15 @@ class BaiKeSpiderPipeline(object):
        2、在自己实现的爬虫类中yield item,会自动执行'''
 
     def __init__(self):
+        # Keep credentials outside source control. The defaults are suitable
+        # for a local MySQL development instance and can be overridden with
+        # the BAIKESPIDER_DB_* environment variables documented in README.md.
         self.dbparams = {
-            'host': '127.0.0.1',
-            'port': 3306,
-            # 'user': 'root',
-            # 'password': '1240',
-            'user': 'yqc',
-            'password': '123456',
-            'db': 'scrapy_baike',
+            'host': os.getenv('BAIKESPIDER_DB_HOST', '127.0.0.1'),
+            'port': int(os.getenv('BAIKESPIDER_DB_PORT', '3306')),
+            'user': os.getenv('BAIKESPIDER_DB_USER', 'root'),
+            'password': os.getenv('BAIKESPIDER_DB_PASSWORD', ''),
+            'db': os.getenv('BAIKESPIDER_DB_NAME', 'scrapy_baike'),
             'charset': 'utf8mb4',
             'cursorclass': pymysql.cursors.DictCursor,
         }

--- a/scrapyspider/pipelines.py
+++ b/scrapyspider/pipelines.py
@@ -35,28 +35,24 @@ class BaiKeSpiderPipeline(object):
         }
 
     def execute_sql(self, sql):
-
         # 连接数据库，存到t中
-        self.db = pymysql.connect(**self.dbparams)  # **表示将字典扩展为关键字参数,相当于host=xxx,db=yyy....
+        self.db = pymysql.connect(**self.dbparams)
         self.cursor = self.db.cursor()
 
         try:
             self.cursor.execute("SET NAMES 'utf8mb4';")
             self.cursor.execute("SET CHARACTER SET 'utf8mb4';")
             self.cursor.execute("SET character_set_connection=utf8mb4")
-            # 执行sql语句
-
-
+            self.cursor.execute(sql)
             self.db.commit()
-            # 提交到数据库执行
-
-            self.db.close()  # 关闭数据库
-            return self.cursor.rowcount  # 返回cursor运行过程中affected rows的数量
-        except:
-            # 如果发生错误则回滚
+            affected_rows = self.cursor.rowcount
+            self.db.close()
+            return affected_rows
+        except Exception:
             print("ERR in sql execution!!; The sql is {}".format(sql))
             self.db.rollback()
-            sys.exit(233)
+            self.db.close()
+            raise
 
     def deal_with_quotes(self, processed_str):  # 处理插入MySQL的引号问题
         return processed_str.replace("\"", "\\\"").replace("\'", "\\\'")
@@ -70,7 +66,7 @@ class BaiKeSpiderPipeline(object):
         descrip     TEXT NOT NULL,
         infobox     TEXT,
         infolink   TEXT,
-        tag         TEXT    
+        tag         TEXT
         );
         """ % table_name
         self.execute_sql(sql)
@@ -93,7 +89,7 @@ class BaiKeSpiderPipeline(object):
 
     def exists_in_table(self, table_name, attribute_name, value_name):
         sql = """
-        SELECT * FROM 
+        SELECT * FROM
         %s
         WHERE %s="%s" ;
         """ % (table_name, attribute_name, self.deal_with_quotes(value_name))
@@ -123,8 +119,8 @@ class BaiKeSpiderPipeline(object):
                     values = "\"%s\"" % self.deal_with_quotes(value)
                     firstRun = False
                 count += 1
-        except:
-            sys.exit(104)
+        except Exception:
+            raise
 
         sql = """
         INSERT INTO %s(%s)
@@ -172,7 +168,7 @@ class PicturePipeline(ImagesPipeline):
     }
 
     # 存储图片到数据库
-    baiduPipelines = BaiKeSpiderPipeline()  # 引用前一个pipelline的各项功能
+    baiduPipelines = BaiKeSpiderPipeline()
     dbparams = baiduPipelines.dbparams
     execute_sql = baiduPipelines.execute_sql
     deal_with_quotes = baiduPipelines.deal_with_quotes
@@ -194,7 +190,6 @@ class PicturePipeline(ImagesPipeline):
         img_list = []
         img_list.append(img_name)
 
-        # 将图片插入实体表
         sql = """
         UPDATE %s
         SET %s=\'%s\'
@@ -209,11 +204,10 @@ class PicturePipeline(ImagesPipeline):
         self.default_headers['referer'] = image_url
         if image_url != "none":
             yield Request(image_url, meta={'image_name': item['image_name']}, headers=self.default_headers)
-            # meta = {'image_name': item['image_name']},
 
     def item_completed(self, results, item, info):
         settings = get_project_settings()
-        images_dir_path = settings.get('IMAGES_STORE')  # 找到存储图片的根目录
+        images_dir_path = settings.get('IMAGES_STORE')
 
         image_paths = [x['path'] for ok, x in results if ok]
         if not image_paths:
@@ -222,7 +216,7 @@ class PicturePipeline(ImagesPipeline):
             image_path = image_paths[0]
             oid_pattern = re.compile("full\/([^\.]+)\.\d+\.jpg")
             m = oid_pattern.match(image_path)
-            oid = m.group(1)  # 图片的count值，对应数据库中的id值
+            oid = m.group(1)
 
             name_pattern = re.compile("full\/([^\.]+\.(\d+)\.jpg)")
             name = name_pattern.match(image_path).group(1)
@@ -233,9 +227,6 @@ class PicturePipeline(ImagesPipeline):
         return item
 
     def file_path(self, request, response=None, info=None):
-        # tmp = request.url.split('/')[-1]
-        # # name = tmp+".jpg"
-        # return 'full/%s' % (tmp)
         return 'full/%s.jpg' % request.meta['image_name']
 
 
@@ -254,41 +245,33 @@ class PictureUrlsPipeline(object):
         'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36',
     }
 
-    baiduPipelines = BaiKeSpiderPipeline()  # 引用前一个pipelline的各项功能
+    baiduPipelines = BaiKeSpiderPipeline()
     dbparams = baiduPipelines.dbparams
 
     def execute_sql(self, sql):
-
-        # 连接数据库，存到t中
-        self.db = pymysql.connect(**self.dbparams)  # **表示将字典扩展为关键字参数,相当于host=xxx,db=yyy....
+        self.db = pymysql.connect(**self.dbparams)
         self.cursor = self.db.cursor()
 
         try:
             self.cursor.execute('SET NAMES utf8mb4')
             self.cursor.execute("SET CHARACTER SET utf8mb4")
             self.cursor.execute("SET character_set_connection=utf8mb4")
-            # 执行sql语句
-
-            # if self.cursor.execute(sql) != 1:
-            #     print(
-            #         "Warning: fetch too many attributes for randow data!!By default excute_sql just return one row's data")
-
+            self.cursor.execute(sql)
+            result = self.cursor.fetchone()
             self.db.commit()
-            # 提交到数据库执行
-
             self.db.close()
-            return self.cursor.fetchone()  # fetchone()只返回sql语句执行的结果中的第一行（字典形式），如：self.cursor.fetchone()['oid']对应此行的oid
-        except:
-            # 如果发生错误则回滚
+            return result
+        except Exception:
             print("ERR in sql execution!!; The sql is {}".format(sql))
             self.db.rollback()
-            sys.exit(233)
+            self.db.close()
+            raise
 
-    def max_id(self, table_name):  # 找出最大的id值
+    def max_id(self, table_name):
         sql = """
         SELECT MAX(id) FROM %s;
         """ % table_name
-        result = int(float(self.execute_sql(sql)['MAX(id)']))  # MySQL默认返回的是浮点类型
+        result = int(float(self.execute_sql(sql)['MAX(id)']))
         print("the max_id is ", result)
         if result <= 0:
             print('Err in get max_id: got max id <= 0')
@@ -298,7 +281,7 @@ class PictureUrlsPipeline(object):
 
     def get_oid(self, table_name, id):
         tbl_max_id = self.max_id(table_name)
-        if id > tbl_max_id:  # 检查id是否越界
+        if id > tbl_max_id:
             print("ERR: The id you give is to big! No such row")
             sys.exit(233)
 
@@ -306,6 +289,6 @@ class PictureUrlsPipeline(object):
         SELECT oid FROM %s
         WHERE id=%s;
         """ % (table_name, id)
-        return self.execute_sql(sql)['oid']  # 注意fetchone返回的是字典类型
+        return self.execute_sql(sql)['oid']
 
 


### PR DESCRIPTION
## Summary

This PR modernizes BaikeSpider's public project surface and fixes a few concrete maintenance problems while keeping the original crawler architecture recognizable.

### Documentation and project presentation
- rewrites `README.md` around the actual crawler architecture, data model, setup, and maintenance status
- adds CI, license, stars/forks, Python, and Scrapy badges
- documents recursive crawling, MySQL persistence, image collection, deduplication, and `JOBDIR`-based resumability
- adds a concise "At a glance" section for quick project evaluation
- clearly states that the crawler targets an older Baidu Baike DOM and may need selector updates

### Open-source project hygiene
- adds an MIT `LICENSE`
- adds `CONTRIBUTING.md`
- adds `.github/CODEOWNERS` identifying `@yangqincheng` as the repository-wide primary maintainer
- adds structured bug-report and enhancement Issue templates
- adds a pull request template
- adds `requirements.txt`, `.gitignore`, and `.env.example`

### Configuration and maintenance fixes
- removes hard-coded MySQL username/password from `pipelines.py`
- reads database configuration from `BAIKESPIDER_DB_*` environment variables
- restores SQL execution in persistence helpers where generated SQL was previously not executed
- improves database cleanup/error propagation around those helpers

### CI
- adds a GitHub Actions workflow that installs dependencies and syntax-checks the Python sources
- the workflow has already completed successfully on this PR

The goal is to make the repository easier for users, contributors, and OSS reviewers to evaluate while keeping every public claim grounded in the current codebase and project history.